### PR TITLE
Verify wasm

### DIFF
--- a/src/Webassembly/compile.bat
+++ b/src/Webassembly/compile.bat
@@ -1,3 +1,4 @@
 rem unvectorized/unthreaded version
 emcc --bind -o shellWasm.wasm.js shellWasm.cpp --std=c++17 -O3 -s ASSERTIONS=1 -s MODULARIZE=1 -s EXPORT_NAME="ShellWasm"^
- -s ENVIRONMENT="web" -s MALLOC=emmalloc -s ALLOW_MEMORY_GROWTH=1 -s FILESYSTEM=0 -s SINGLE_FILE=1 --closure 1 -flto -v
+ -s ENVIRONMENT="web" -s MALLOC=emmalloc -s ALLOW_MEMORY_GROWTH=1 -s FILESYSTEM=0 -s SINGLE_FILE=1 --closure 1 -flto -v^
+ -Wall -Wextra -Wpedantic

--- a/src/Webassembly/compile_threads.bat
+++ b/src/Webassembly/compile_threads.bat
@@ -1,4 +1,4 @@
 rem experimental multithreaded version
 emcc --bind -o shellWasmT.wasm.js shellWasm.cpp --std=c++17 -O3 -s ASSERTIONS=1 -s MODULARIZE=1 -s EXPORT_NAME="ShellWasmT"^
  -s ENVIRONMENT="web,worker" -s MALLOC=dlmalloc -s ALLOW_MEMORY_GROWTH=1 -s FILESYSTEM=0 -s SINGLE_FILE=1 --closure 1 -flto^
- -v
+ -v -Wall -Wextra -Wpedantic

--- a/src/Webassembly/compile_threads_vectorized.bat
+++ b/src/Webassembly/compile_threads_vectorized.bat
@@ -1,4 +1,4 @@
 rem experimental multithreaded and vectorized version
 emcc --bind -o shellWasmTV.wasm.js shellWasm.cpp --std=c++17 -O3 -s ASSERTIONS=1 -s MODULARIZE=1 -s EXPORT_NAME="ShellWasmTV"^
  -s ENVIRONMENT="web,worker" -s MALLOC=dlmalloc -s ALLOW_MEMORY_GROWTH=1 -s FILESYSTEM=0 -s SINGLE_FILE=1 --closure 1 -flto^
- -msimd128 -v
+ -msimd128 -v -Wall -Wextra -Wpedantic

--- a/src/Webassembly/compile_vectorized.bat
+++ b/src/Webassembly/compile_vectorized.bat
@@ -1,3 +1,4 @@
 rem vectorized/unthreaded version
 emcc --bind -o shellWasmV.wasm.js shellWasm.cpp --std=c++17 -O3 -s ASSERTIONS=1 -s MODULARIZE=1 -s EXPORT_NAME="ShellWasmV"^
- -s ENVIRONMENT="web" -s MALLOC=emmalloc -s ALLOW_MEMORY_GROWTH=1 -s FILESYSTEM=0 -s SINGLE_FILE=1 --closure 1 -flto -msimd128 -v 
+ -s ENVIRONMENT="web" -s MALLOC=emmalloc -s ALLOW_MEMORY_GROWTH=1 -s FILESYSTEM=0 -s SINGLE_FILE=1 --closure 1 -flto -msimd128 -v^
+ -Wall -Wextra -Wpedantic

--- a/src/Webassembly/shellWasm.cpp
+++ b/src/Webassembly/shellWasm.cpp
@@ -198,6 +198,16 @@ class shellCalcWasm : public wows_shell::shellCalc {
     public:
     shellCalcWasm() = default;
 
+    void setMax(const double max){set_max(max);}
+    void setMin(const double min) { set_min(min); }
+    void setPrecision(const double precision) { set_precision(precision); }
+    void setX0(const double x0) { set_x0(x0); }
+    void setY0(const double y0) { set_y0(y0); }
+    void setDtMin(const double dt) { set_dt_min(dt); }
+    void setXf0(const double xf0) { set_xf0(xf0); }
+    void setYf0(const double yf0) { set_yf0(yf0); }
+    void setDtf(const double dtf) { set_dtf(dtf); }
+
     template <wows_shell::numerical Numerical>
     void calcImpact(shellWasm &sp){
         #ifdef __EMSCRIPTEN_PTHREADS__
@@ -220,7 +230,7 @@ class shellCalcWasm : public wows_shell::shellCalc {
                      const double inclination, emscripten::val anglesVal,
                      const bool changeDirection, const bool fast) {
         std::vector<double> input =
-            std::move(emscripten::convertJSArrayToNumberVector<double>(anglesVal));
+            emscripten::convertJSArrayToNumberVector<double>(anglesVal);
         #ifdef __EMSCRIPTEN_PTHREADS__
         calculatePostPen(thickness, inclination, sp.s, input, changeDirection,
                          fast);
@@ -346,7 +356,7 @@ class shellCombined {
                      emscripten::val v, const bool changeDirection,
                      const bool fast) {
         std::vector<double> input =
-            std::move(emscripten::convertJSArrayToNumberVector<double>(v));
+            emscripten::convertJSArrayToNumberVector<double>(v);
         for (auto &s : ships) {
             #ifdef __EMSCRIPTEN_PTHREADS__
             calc.calculatePostPen(thickness, inclination, s, input,
@@ -454,15 +464,15 @@ EMSCRIPTEN_BINDINGS(shellWasm) {
     
     emscripten::class_<shellCalcWasm>("shellCalc")
         .constructor()
-        .function("setMax", &shellCalcWasm::set_max)
-        .function("setMin", &shellCalcWasm::set_min)
-        .function("setPrecision", &shellCalcWasm::set_precision)
-        .function("setX0", &shellCalcWasm::set_x0)
-        .function("setY0", &shellCalcWasm::set_y0)
-        .function("setDtMin", &shellCalcWasm::set_dt_min)
-        .function("setXf0", &shellCalcWasm::set_xf0)
-        .function("setYf0", &shellCalcWasm::set_yf0)
-        .function("setDtf", &shellCalcWasm::set_dtf)
+        .function("setMax", &shellCalcWasm::setMax)
+        .function("setMin", &shellCalcWasm::setMin)
+        .function("setPrecision", &shellCalcWasm::setPrecision)
+        .function("setX0", &shellCalcWasm::setX0)
+        .function("setY0", &shellCalcWasm::setY0)
+        .function("setDtMin", &shellCalcWasm::setDtMin)
+        .function("setXf0", &shellCalcWasm::setXf0)
+        .function("setYf0", &shellCalcWasm::setYf0)
+        .function("setDtf", &shellCalcWasm::setDtf)
         .function("calcImpact",
                   &shellCalcWasm::calcImpact<wows_shell::numerical::forwardEuler>)
         .function("calcImpactAdamsBashforth5",

--- a/src/Webassembly/shellWasmTest.html
+++ b/src/Webassembly/shellWasmTest.html
@@ -21,8 +21,8 @@
         runFuncSplit();
     }
 
-    if (false) {
-        //if (typeof wasmFeatureDetect !== 'undefined') {
+    //if (false) {
+    if (typeof wasmFeatureDetect !== 'undefined') {
         console.log('wasmFeatureDetect Working');
         wasmFeatureDetect.threads().then(threadsSupported => {
             wasmFeatureDetect.simd().then(simdSupported => {
@@ -37,7 +37,13 @@
                     }
                 } else {
                     console.log('unthreaded');
-                    ShellWasm().then(instantiateModule);
+                    if (simdSupported) {
+                        console.log('vectorized');
+                        ShellWasmV().then(instantiateModule);
+                    } else {
+                        console.log('unvectorized');
+                        ShellWasm().then(instantiateModule)
+                    }
                 }
             });
         });

--- a/src/Webassembly/shellWasmTest.html
+++ b/src/Webassembly/shellWasmTest.html
@@ -5,9 +5,10 @@
 <script>
     !function (e, a) { "object" == typeof exports && "undefined" != typeof module ? module.exports = a() : "function" == typeof define && define.amd ? define(a) : (e = e || self).wasmFeatureDetect = a() }(this, (function () { "use strict"; return { bigInt: () => (async e => { try { return (await WebAssembly.instantiate(e)).instance.exports.b(BigInt(0)) === BigInt(0) } catch (e) { return !1 } })(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 6, 1, 96, 1, 126, 1, 126, 3, 2, 1, 0, 7, 5, 1, 1, 98, 0, 0, 10, 6, 1, 4, 0, 32, 0, 11])), bulkMemory: async () => WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 5, 3, 1, 0, 1, 10, 14, 1, 12, 0, 65, 0, 65, 0, 65, 0, 252, 10, 0, 0, 11])), exceptions: async () => WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 10, 9, 1, 7, 0, 6, 64, 7, 26, 11, 11])), multiValue: async () => WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 6, 1, 96, 0, 2, 127, 127, 3, 2, 1, 0, 10, 8, 1, 6, 0, 65, 0, 65, 0, 11])), mutableGlobals: async () => WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 2, 8, 1, 1, 97, 1, 98, 3, 127, 1, 6, 6, 1, 127, 1, 65, 0, 11, 7, 5, 1, 1, 97, 3, 1])), referenceTypes: async () => WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 10, 7, 1, 5, 0, 208, 112, 26, 11])), saturatedFloatToInt: async () => WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 10, 12, 1, 10, 0, 67, 0, 0, 0, 0, 252, 0, 26, 11])), signExtensions: async () => WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 10, 8, 1, 6, 0, 65, 0, 192, 26, 11])), simd: async () => WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 10, 9, 1, 7, 0, 65, 0, 253, 15, 26, 11])), tailCall: async () => WebAssembly.validate(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 10, 6, 1, 4, 0, 18, 0, 11])), threads: () => (async e => { try { return (new ("undefined" != typeof MessageChannel ? MessageChannel : await import("worker_threads").then(e => e.MessageChannel))).port1.postMessage(new SharedArrayBuffer(1)), WebAssembly.validate(e) } catch (e) { return !1 } })(new Uint8Array([0, 97, 115, 109, 1, 0, 0, 0, 1, 4, 1, 96, 0, 0, 3, 2, 1, 0, 5, 4, 1, 3, 1, 1, 10, 11, 1, 9, 0, 65, 0, 254, 16, 2, 0, 26, 11])) } }));
 </script>
+<script type="text/javascript" src="shellWasm.wasm.js"></script>
 <script type="text/javascript" src="shellWasmTV.wasm.js"></script>
 <script type="text/javascript" src="shellWasmT.wasm.js"></script>
-<script type="text/javascript" src="shellWasm.wasm.js"></script>
+
 <script>
     console.log('Started');
     let Module;
@@ -20,7 +21,8 @@
         runFuncSplit();
     }
 
-    if (typeof wasmFeatureDetect !== 'undefined') {
+    if (false) {
+        //if (typeof wasmFeatureDetect !== 'undefined') {
         console.log('wasmFeatureDetect Working');
         wasmFeatureDetect.threads().then(threadsSupported => {
             wasmFeatureDetect.simd().then(simdSupported => {
@@ -127,6 +129,11 @@
     const runFuncSplit = () => {
         const shells = [];
         const calc = new Module.shellCalc();
+        calc.setMax(30);
+        calc.setMin(0);
+        calc.setPrecision(0.1);
+        calc.setDtMin(0.01);
+
         for (const data of shellData) {
             shells.push(new Module.shell(...data, ''));
         }


### PR DESCRIPTION
fix: shellCalc characteristics setters not working in js
fix: std::move preventing copy elision while passing postPen angles
fix: added warnings to compile commands
feature: added test for unthreaded vectorized version